### PR TITLE
fix : JwtTokenProvider getId() 오류 수정

### DIFF
--- a/src/main/java/matchingGoal/matchingGoal/common/auth/JwtTokenProvider.java
+++ b/src/main/java/matchingGoal/matchingGoal/common/auth/JwtTokenProvider.java
@@ -96,6 +96,10 @@ public class JwtTokenProvider {
     }
 
     public  Long getId(String token){
-        return Long.valueOf(Jwts.parser().setSigningKey(secretKey).parseClaimsJws(getRawToken(token)).getBody().getId());
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(getRawToken(token))
+                .getBody()
+                .get("id", Long.class);
     }
 }


### PR DESCRIPTION
## 개요

getBody().get("id", Long.class) 메서드를 사용하여 클레임에서 ID 값을 가져오고, 이를 Long으로 변환하도록 변경했습니다.
클레임에 저장된 ID 값의 타입에 관계없이 Long으로 반환되기 때문입니다. 

resolves: #15

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
