### PR TITLE
fix : 중복 로그아웃 시 토큰 저장 오류 수정 

### DIFF
--- a/src/main/java/matchingGoal/matchingGoal/common/auth/JwtTokenProvider.java
+++ b/src/main/java/matchingGoal/matchingGoal/common/auth/JwtTokenProvider.java
@@ -51,7 +51,7 @@ public class JwtTokenProvider {
     public void validateToken(String token) {
         try {
             // 로그아웃한 토큰일 경우
-            if (redisService.getData(BLACK_TOKEN_PREFIX + getEmail(token)) != null)
+            if (redisService.hasKeyAndValue( BLACK_TOKEN_PREFIX + getEmail(token) , token))
                 throw new ExpiredTokenException();
 
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
@@ -114,6 +114,6 @@ public class JwtTokenProvider {
     }
 
     public void setBlacklist(String token) {
-        redisService.setData(BLACK_TOKEN_PREFIX + getEmail(token), token, refreshTokenExpirationTimeInSeconds);
+        redisService.setBlackList(BLACK_TOKEN_PREFIX + getEmail(token), token, refreshTokenExpirationTimeInSeconds);
     }
 }

--- a/src/main/java/matchingGoal/matchingGoal/common/service/RedisService.java
+++ b/src/main/java/matchingGoal/matchingGoal/common/service/RedisService.java
@@ -26,4 +26,14 @@ public class RedisService {
         Boolean keyExists = stringRedisTemplate.hasKey(email);
         return keyExists != null && keyExists;
     }
+
+    public void setBlackList(String key, String value, long durationInMinutes) {
+        stringRedisTemplate.opsForSet().add(key, value);
+        stringRedisTemplate.expire(key, durationInMinutes, TimeUnit.MINUTES);
+    }
+
+    public boolean hasKeyAndValue(String key, String value){
+        System.out.println(key +"  " + value);
+        return Boolean.TRUE.equals(stringRedisTemplate.opsForSet().isMember(key, value));
+    }
 }

--- a/src/main/java/matchingGoal/matchingGoal/common/type/ErrorCode.java
+++ b/src/main/java/matchingGoal/matchingGoal/common/type/ErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-      
+
     //common
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST,"입력된 값이 올바르지 않습니다"),
 
@@ -17,7 +17,7 @@ public enum ErrorCode {
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다"),
     INVALID_TOKEN(HttpStatus.NOT_FOUND, "토큰 정보를 찾을 수 없습니다"),
     WITHDRAWN_MEMBER(HttpStatus.BAD_REQUEST, "탈퇴한 사용자 입니다"),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST,"만료된 토큰입니다"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED,"만료된 토큰입니다"),
 
     // member
     MEMBER_NOT_EXISTS(HttpStatus.NOT_FOUND,"사용자를 찾을 수 없습니다"),

--- a/src/main/java/matchingGoal/matchingGoal/member/controller/AuthController.java
+++ b/src/main/java/matchingGoal/matchingGoal/member/controller/AuthController.java
@@ -2,7 +2,7 @@ package matchingGoal.matchingGoal.member.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import matchingGoal.matchingGoal.member.dto.MemberRegisterDto;
+import matchingGoal.matchingGoal.member.dto.SignUpDto;
 import matchingGoal.matchingGoal.member.dto.SignInDto;
 import matchingGoal.matchingGoal.member.dto.GetPasswordDto;
 import matchingGoal.matchingGoal.member.dto.SignInResponse;
@@ -25,7 +25,7 @@ public class AuthController {
      * @return "회원가입 성공"
      */
     @PostMapping("/sign-up")
-    public ResponseEntity<String> registerMember(@Valid @RequestBody MemberRegisterDto registerDto) {
+    public ResponseEntity<String> registerMember(@Valid @RequestBody SignUpDto registerDto) {
         return ResponseEntity.ok().body(authService.registerMember(registerDto));
     }
 

--- a/src/main/java/matchingGoal/matchingGoal/member/dto/SignInResponse.java
+++ b/src/main/java/matchingGoal/matchingGoal/member/dto/SignInResponse.java
@@ -12,7 +12,7 @@ public class SignInResponse {
 
     private String refreshToken;
 
-    private Long id;
+    private Long memberId;
 
     private String nickname;
 

--- a/src/main/java/matchingGoal/matchingGoal/member/dto/SignUpDto.java
+++ b/src/main/java/matchingGoal/matchingGoal/member/dto/SignUpDto.java
@@ -12,7 +12,7 @@ import matchingGoal.matchingGoal.common.annotation.Password;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class MemberRegisterDto {
+public class SignUpDto {
 
     @NotBlank(message = "이름을 입력해주세요")
     private String name;

--- a/src/main/java/matchingGoal/matchingGoal/member/service/AuthService.java
+++ b/src/main/java/matchingGoal/matchingGoal/member/service/AuthService.java
@@ -6,12 +6,11 @@ import lombok.extern.slf4j.Slf4j;
 import matchingGoal.matchingGoal.common.auth.JwtToken;
 import matchingGoal.matchingGoal.common.auth.JwtTokenProvider;
 import matchingGoal.matchingGoal.common.service.RedisService;
-import matchingGoal.matchingGoal.image.service.ImageService;
 import matchingGoal.matchingGoal.member.dto.SignInDto;
 import matchingGoal.matchingGoal.member.dto.GetPasswordDto;
 import matchingGoal.matchingGoal.member.dto.SignInResponse;
 import matchingGoal.matchingGoal.member.exception.*;
-import matchingGoal.matchingGoal.member.dto.MemberRegisterDto;
+import matchingGoal.matchingGoal.member.dto.SignUpDto;
 import matchingGoal.matchingGoal.member.model.entity.Member;
 import matchingGoal.matchingGoal.member.repository.MemberRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -36,7 +35,7 @@ public class AuthService {
      * @param registerDto - 회원가입 dto
      * @return "회원가입 성공"
      */
-    public String registerMember(MemberRegisterDto registerDto) {
+    public String registerMember(SignUpDto registerDto) {
 
         // 이메일 중복 확인
         if(memberRepository.findByEmail(registerDto.getEmail()).isPresent())

--- a/src/main/java/matchingGoal/matchingGoal/member/service/AuthService.java
+++ b/src/main/java/matchingGoal/matchingGoal/member/service/AuthService.java
@@ -27,8 +27,6 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
     private final MemberService memberService;
-    private final RedisService redisService;
-    private final String TOKEN_PREFIX = "RT_";
 
     /**
      * 회원가입
@@ -112,12 +110,6 @@ public class AuthService {
      */
     public String signOut(String token) {
         jwtTokenProvider.validateToken(token);
-
-        String email = jwtTokenProvider.getEmail(token);
-
-        if (redisService.getData(TOKEN_PREFIX + email) == null) {
-            throw new ExpiredTokenException();
-        }
 
         // 블랙 리스트에 추가(로그아웃)
         jwtTokenProvider.setBlacklist(token);

--- a/src/main/java/matchingGoal/matchingGoal/member/service/AuthService.java
+++ b/src/main/java/matchingGoal/matchingGoal/member/service/AuthService.java
@@ -100,7 +100,7 @@ public class AuthService {
         return SignInResponse.builder()
                 .accessToken(tokens.getAccessToken())
                 .refreshToken(tokens.getRefreshToken())
-                .id(member.getId())
+                .memberId(member.getId())
                 .nickname(member.getNickname())
                 //.imageUrl(imageUrl)
                 .build();

--- a/src/test/java/matchingGoal/matchingGoal/member/service/AuthServiceTest.java
+++ b/src/test/java/matchingGoal/matchingGoal/member/service/AuthServiceTest.java
@@ -1,6 +1,6 @@
 package matchingGoal.matchingGoal.member.service;
 
-import matchingGoal.matchingGoal.member.dto.MemberRegisterDto;
+import matchingGoal.matchingGoal.member.dto.SignUpDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,7 +17,7 @@ class AuthServiceTest {
     String invalidPw2 = "pass123";  //len < 10
     String invalidPw3 = "123456!!!!";  // no alpha
 
-    MemberRegisterDto invalid_registerDto_1 = MemberRegisterDto.builder()
+    SignUpDto invalid_registerDto_1 = SignUpDto.builder()
             .email("test_00@gmail.com")
             .name("test111")
             .password(invalidPw1)
@@ -26,7 +26,7 @@ class AuthServiceTest {
             .region("seoul")
             .build();
 
-    MemberRegisterDto invalid_registerDto_2 = MemberRegisterDto.builder()
+    SignUpDto invalid_registerDto_2 = SignUpDto.builder()
             .email("test_11@gmail.com")
             .name("test111")
             .password(invalidPw2)
@@ -34,7 +34,7 @@ class AuthServiceTest {
             .introduction("hello, there")
             .region("seoul")
             .build();
-    MemberRegisterDto invalid_registerDto_3 = MemberRegisterDto.builder()
+    SignUpDto invalid_registerDto_3 = SignUpDto.builder()
             .email("test_22@gmail.com")
             .name("test111")
             .password(invalidPw3)
@@ -42,7 +42,7 @@ class AuthServiceTest {
             .introduction("hello, there")
             .region("seoul")
             .build();
-    MemberRegisterDto valid_registerDto = MemberRegisterDto.builder()
+    SignUpDto valid_registerDto = SignUpDto.builder()
             .email("test111@gmail.com")
             .name("test111")
             .password(validPw)


### PR DESCRIPTION
## 개요

redis에서 토큰이 삭제 되기 전, 같은 이메일로 로그인 - 로그아웃을 다회 하면, redis에 정보가 제대로 저장하지 않는 오류 수정 

<변경사항> 
- redis에 set을 이용하여 값을 저장하는 setBlackList 와 값이 있는지 조회하는 hasKeyAndValue 함수 생성 
- 로그아웃 시, redisService.setData( ) -> redisService.setBlackList( ) 로 저장 
- 토큰이 valid 한지 확인 할 때,  hasKeyAndValue 함수 활용 
- 회원가입 dto 이름 변경 (커밋 참조) 
- 로그인 response 변수명 수정 (커밋 참조) 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
