### PR TITLE
refactor : ErrorResponse에 에러메세지 반환하는 항목 'errors' 추가

### DIFF
--- a/src/main/java/matchingGoal/matchingGoal/common/exception/ErrorResponse.java
+++ b/src/main/java/matchingGoal/matchingGoal/common/exception/ErrorResponse.java
@@ -6,6 +6,7 @@ import matchingGoal.matchingGoal.common.type.ErrorCode;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Data
 @Builder
@@ -15,6 +16,7 @@ public class ErrorResponse {
     private final String error;
     private final String code;
     private final String message;
+    private final Map<String, String> errors;
 
     public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode e){
         return ResponseEntity

--- a/src/main/java/matchingGoal/matchingGoal/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/matchingGoal/matchingGoal/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,15 @@
 package matchingGoal.matchingGoal.common.exception;
 
 import matchingGoal.matchingGoal.common.type.ErrorCode;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler  {
@@ -16,6 +21,17 @@ public class GlobalExceptionHandler  {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException e) {
-        return ErrorResponse.toResponseEntity(ErrorCode.INVALID_ARGUMENT);
+        Map<String, String> error = new HashMap<>();
+        e.getBindingResult().getAllErrors()
+                .forEach(c -> {
+                    error.put( ((FieldError) c).getField(), c.getDefaultMessage());
+                });
+
+        return ResponseEntity.badRequest().body(ErrorResponse.builder()
+                        .status(HttpStatus.BAD_REQUEST.value())
+                        .error(HttpStatus.BAD_REQUEST.name())
+                        .code(ErrorCode.INVALID_ARGUMENT.toString())
+                        .errors(error)
+                .build());
     }
 }


### PR DESCRIPTION
## 개요

ErrorResponse 에 Map<String,String> 의 errors 항목을 추가. 
- 여러 항목에서 유효성검증 오류가 났을 경우, 오류난 부분들의 오류 메세지들이 errors에 담겨서 반환
- BindingResult 의 fieldError 에서 { field : defaultMessage } 의 형태로 추가. 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
